### PR TITLE
Use Remote Timers from Conductor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Conductor - Ensemble Timers in your Terminal
+
+Display an Ensemble (aka Mob Programming) Timer in the Terminal built into your IDE.
+This allows us to stay within our IDE more.
+
+In addition, we'll integrate Conductor with the [mob.sh](https://mob.sh) command line tool, so you can run `mob next`
+and `mob start` commands from within Conductor (some day it might even run them for you at specific points in time).
+
+## Dependencies
+
+This project uses
+
+* Java 22
+* The [jline](https://github.com/jline/jline3) library for interacting with the terminal
+* The [just](https://github.com/casey/just) command line runner
+
+## Build and Run
+
+The following command will use the Maven wrapper to package the project:
+
+```shell
+just build
+```
+
+If you want to re-run the application without building it, you can use:
+
+```shell
+just run
+```
+
+If you want to re-build and then run it, use:
+
+```shell
+just all
+```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This allows us to stay within our IDE more.
 In addition, we'll integrate Conductor with the [mob.sh](https://mob.sh) command line tool, so you can run `mob next`
 and `mob start` commands from within Conductor (some day it might even run them for you at specific points in time).
 
+[![asciicast](https://asciinema.org/a/osBaFnrpvGH13GADqdZxjvHwy.svg)](https://asciinema.org/a/osBaFnrpvGH13GADqdZxjvHwy)
+
 ## Dependencies
 
 This project uses

--- a/diagrams/RemoteTimer.puml
+++ b/diagrams/RemoteTimer.puml
@@ -1,26 +1,53 @@
 @startuml
 'https://plantuml.com/sequence-diagram
 
-footbox off
 skinparam ParticipantPadding 10
 skinparam BoxPadding 20
 
-box InAdapters #F1E6FF
+box In Adapters #F1E6FF
 participant Scheduler as scheduler
+participant "Line Reader" as reader
 box Application #FFEFE6
-participant "main()" as main
+participant "Root" as root
 box Domain #F7F0D2
 participant Timer as timer
-box OutAdapters #DAE4F7
+box Out Adapters #DAE4F7
 participant "API" as api
 participant "Terminal UI" as tui
 
+group Tick
 scheduler --> scheduler: 1 second passed
-scheduler -> main: per-second-callback()
-main -> api: fetchTimer()
+scheduler -> root: per-second-callback()
+activate root
+root -> api: fetchTimer()
+activate api
 api -> timer: new()
 api <-- timer: <timer>
-main <-- api: <timer>
-main -> tui: render app state(timer)
+return <timer>
+'root <-- api: <timer>
+'deactivate api
+root -> tui: render app state(timer)
+deactivate root
+end
+
+group Pause
+' make the box span the full width
+scheduler -[hidden]-> tui
+
+reader -> root: "pause" command
+activate root
+root -> api: pauseTimer()
+activate api
+return
+root -> api: fetchTimer()
+activate api
+api -> timer: new()
+api <-- timer: <timer>
+return <timer>
+root -> tui: render app state(timer)
+deactivate root
+
+end
+
 
 @enduml

--- a/src/main/java/ninja/ranner/conductor/ConductorApplication.java
+++ b/src/main/java/ninja/ranner/conductor/ConductorApplication.java
@@ -1,40 +1,57 @@
 package ninja.ranner.conductor;
 
 import ninja.ranner.conductor.adapter.in.clock.Scheduler;
+import ninja.ranner.conductor.adapter.out.http.ConductorApiClient;
 import ninja.ranner.conductor.adapter.out.terminal.Lines;
 import ninja.ranner.conductor.adapter.out.terminal.TerminalUi;
 import ninja.ranner.conductor.adapter.out.terminal.TimerTransformer;
-import ninja.ranner.conductor.domain.Timer;
+import ninja.ranner.conductor.domain.RemoteTimer;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class ConductorApplication {
 
-    private static String lastCommand = "";
-    private static final Timer timer = new Timer(5);
+    private static final String timerName = "my-timer";
+    private static final ConductorApiClient apiClient = ConductorApiClient.create("http://localhost:8080");
 
     public static void main(String[] args) throws Exception {
-        TerminalUi tui = TerminalUi.create();
+        TerminalUi tui = TerminalUi.create(List.of(
+                "quit",
+                "load",
+                "save",
+                "pause",
+                "start",
+                "rotate"));
 
         tui.registerCommandHandler(cmd -> {
-            lastCommand = cmd;
-            renderAppState(tui);
+            try {
+                switch (cmd) {
+                    case "start" -> apiClient.startTimer(timerName);
+                    case "pause" -> apiClient.pauseTimer(timerName);
+                    case "rotate" -> apiClient.nextTurn(timerName);
+                }
+            } catch (Exception e) {
+                // ignored (for now)
+            }
         });
-        renderAppState(tui);
-        try (AutoCloseable ignored = Scheduler.create(TimeUnit.SECONDS).start(() -> {
-            timer.tick();
-            renderAppState(tui);
-        })) {
+        Scheduler scheduler = Scheduler.create(TimeUnit.SECONDS);
+        try (AutoCloseable ignored = scheduler.start(() -> renderRemoteTimer(tui))) {
             tui.run();
         }
     }
 
-    private static void renderAppState(TerminalUi tui) {
-        Lines lines = new TimerTransformer(timer).transform();
-        if (!lastCommand.isEmpty()) {
-            lines.append("", "You said: " + lastCommand);
+    private static void renderRemoteTimer(TerminalUi terminalUi) {
+        TimerTransformer transformer = new TimerTransformer(null);
+        try {
+            Optional<RemoteTimer> timer = apiClient.fetchTimer(timerName);
+            Lines lines = transformer.transform(timer.orElseThrow());
+            terminalUi.update(lines);
+        } catch (Exception e) {
+            terminalUi.update(Lines.of("Failed to fetch remote timer:", e.getMessage()));
         }
-        tui.update(lines);
+
     }
 
 }

--- a/src/main/java/ninja/ranner/conductor/ConductorApplication.java
+++ b/src/main/java/ninja/ranner/conductor/ConductorApplication.java
@@ -11,9 +11,13 @@ import java.util.concurrent.TimeUnit;
 public class ConductorApplication {
 
     private static final String timerName = "my-timer";
-    private static final ConductorApiClient apiClient = ConductorApiClient.create("http://localhost:8080");
+    private static final ConductorApiClient apiClient = ConductorApiClient
+            .create("http://localhost:8080");
 
     public static void main(String[] args) throws Exception {
+        // The list of available commands and how to handle them
+        // should move out of this method to ... somewhere else.
+        // But, is that an In Adapter or an Application level concern?
         TerminalUi tui = TerminalUi.create(List.of(
                 "quit",
                 "load",
@@ -37,7 +41,7 @@ public class ConductorApplication {
         Root root = new Root(
                 Scheduler.create(TimeUnit.SECONDS),
                 tui,
-                ConductorApiClient.create("http://localhost:8080"),
+                apiClient,
                 timerName
         );
         root.startInBackground().join();

--- a/src/main/java/ninja/ranner/conductor/adapter/OutputTracker.java
+++ b/src/main/java/ninja/ranner/conductor/adapter/OutputTracker.java
@@ -2,6 +2,7 @@ package ninja.ranner.conductor.adapter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class OutputTracker<T> {
@@ -20,7 +21,12 @@ public class OutputTracker<T> {
             throw new IllegalStateException("Expected output to have a single element, but output was empty");
         }
         if (entries.size() > 1) {
-            throw new IllegalStateException("Expected output to have a single element, but found: " + entries.size());
+            throw new IllegalStateException("Expected output to have a single element, but found: %d\n\n%s".formatted(
+                    entries.size(),
+                    entries.stream()
+                            .map(Object::toString)
+                            .collect(Collectors.joining("\n"))
+            ));
         }
         return entries.getFirst();
     }

--- a/src/main/java/ninja/ranner/conductor/adapter/out/terminal/Lines.java
+++ b/src/main/java/ninja/ranner/conductor/adapter/out/terminal/Lines.java
@@ -28,4 +28,13 @@ public class Lines {
     public int size() {
         return lines.size();
     }
+
+    @Override
+    public String toString() {
+        StringBuilder allLines = new StringBuilder();
+        lines.stream()
+                .map("%s\n"::formatted)
+                .forEach(allLines::append);
+        return allLines.toString();
+    }
 }

--- a/src/main/java/ninja/ranner/conductor/adapter/out/terminal/TerminalUi.java
+++ b/src/main/java/ninja/ranner/conductor/adapter/out/terminal/TerminalUi.java
@@ -1,5 +1,7 @@
 package ninja.ranner.conductor.adapter.out.terminal;
 
+import ninja.ranner.conductor.adapter.OutputListener;
+import ninja.ranner.conductor.adapter.OutputTracker;
 import org.jline.reader.*;
 import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
@@ -16,6 +18,7 @@ import java.util.function.Function;
 public class TerminalUi {
     private final LineReader reader;
     private final ATerminal terminal;
+    private final OutputListener<String> screenListener = new OutputListener<>();
     private Lines lines = Lines.of();
     private Consumer<String> commandHandler = ignored -> {
     };
@@ -70,6 +73,8 @@ public class TerminalUi {
     }
 
     private void render() {
+        screenListener.emit(lines.toString());
+
         terminal.puts(InfoCmp.Capability.clear_screen);
 
         lines.all().forEach(terminal::println);
@@ -99,6 +104,10 @@ public class TerminalUi {
     public static Fixture createNull(Function<Config, Config> configure) {
         Config config = configure.apply(new Config());
         return config.createFixture();
+    }
+
+    public OutputTracker<String> trackScreens() {
+        return screenListener.track();
     }
 
     public record Fixture(TerminalUi terminalUi, Controls controls) {

--- a/src/main/java/ninja/ranner/conductor/adapter/out/terminal/TimerTransformer.java
+++ b/src/main/java/ninja/ranner/conductor/adapter/out/terminal/TimerTransformer.java
@@ -1,5 +1,6 @@
 package ninja.ranner.conductor.adapter.out.terminal;
 
+import ninja.ranner.conductor.domain.RemoteTimer;
 import ninja.ranner.conductor.domain.Timer;
 
 public class TimerTransformer {
@@ -17,4 +18,33 @@ public class TimerTransformer {
         }
         return Lines.of(String.valueOf(remainingSeconds));
     }
+
+    public Lines transform(RemoteTimer timer) {
+        Lines lines = Lines.of(
+                "Time:        %s".formatted(renderRemainingTime(timer)),
+                ""
+        );
+        if (timer.participants().size() > 0) {
+            lines.append("Navigator:   %s".formatted(timer.participants().get(0)));
+        }
+        if (timer.participants().size() > 1) {
+            lines.append("Driver:      %s".formatted(timer.participants().get(1)));
+        }
+        if (timer.participants().size() > 2) {
+            lines.append("Next Driver: %s".formatted(timer.participants().get(2)));
+        }
+        return lines;
+    }
+
+    private String renderRemainingTime(RemoteTimer timer) {
+        if (timer.remaining().isZero()) {
+            return "Turn is up!";
+        }
+        long totalSeconds = timer.remaining().getSeconds();
+        long minutes = totalSeconds / 60;
+        long seconds = totalSeconds - minutes * 60;
+
+        return "%02d:%02d | %s".formatted(minutes, seconds, timer.state());
+    }
+
 }

--- a/src/main/java/ninja/ranner/conductor/adapter/out/terminal/TimerTransformer.java
+++ b/src/main/java/ninja/ranner/conductor/adapter/out/terminal/TimerTransformer.java
@@ -24,6 +24,7 @@ public class TimerTransformer {
                 "Time:        %s".formatted(renderRemainingTime(timer)),
                 ""
         );
+        //noinspection SizeReplaceableByIsEmpty
         if (timer.participants().size() > 0) {
             lines.append("Navigator:   %s".formatted(timer.participants().get(0)));
         }

--- a/src/main/java/ninja/ranner/conductor/application/Root.java
+++ b/src/main/java/ninja/ranner/conductor/application/Root.java
@@ -1,0 +1,45 @@
+package ninja.ranner.conductor.application;
+
+import ninja.ranner.conductor.adapter.in.clock.Scheduler;
+import ninja.ranner.conductor.adapter.out.http.ConductorApiClient;
+import ninja.ranner.conductor.adapter.out.terminal.TerminalUi;
+import ninja.ranner.conductor.adapter.out.terminal.TimerTransformer;
+import ninja.ranner.conductor.domain.RemoteTimer;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class Root {
+    private final TerminalUi terminalUi;
+    private final Scheduler scheduler;
+    private final ConductorApiClient apiClient;
+    private final String timerName;
+
+    public Root(Scheduler scheduler, TerminalUi terminalUi, ConductorApiClient apiClient, String timerName) {
+        this.terminalUi = terminalUi;
+        this.scheduler = scheduler;
+        this.apiClient = apiClient;
+        this.timerName = timerName;
+    }
+
+    public Thread startInBackground() {
+        return Thread.startVirtualThread(() -> {
+            try (AutoCloseable ignored = scheduler.start(this::render)) {
+                terminalUi.run();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void render() {
+        try {
+            Optional<RemoteTimer> timer = apiClient.fetchTimer(timerName);
+            timer.ifPresent(t -> {
+                terminalUi.update(new TimerTransformer(null).transform(t));
+            });
+        } catch (IOException | InterruptedException e) {
+            // ignore
+        }
+    }
+}

--- a/src/main/java/ninja/ranner/conductor/application/Root.java
+++ b/src/main/java/ninja/ranner/conductor/application/Root.java
@@ -4,10 +4,8 @@ import ninja.ranner.conductor.adapter.in.clock.Scheduler;
 import ninja.ranner.conductor.adapter.out.http.ConductorApiClient;
 import ninja.ranner.conductor.adapter.out.terminal.TerminalUi;
 import ninja.ranner.conductor.adapter.out.terminal.TimerTransformer;
-import ninja.ranner.conductor.domain.RemoteTimer;
 
 import java.io.IOException;
-import java.util.Optional;
 
 public class Root {
     private final TerminalUi terminalUi;
@@ -34,10 +32,11 @@ public class Root {
 
     private void render() {
         try {
-            Optional<RemoteTimer> timer = apiClient.fetchTimer(timerName);
-            timer.ifPresent(t -> {
-                terminalUi.update(new TimerTransformer(null).transform(t));
-            });
+            TimerTransformer transformer = new TimerTransformer(null);
+            apiClient
+                    .fetchTimer(timerName)
+                    .map(transformer::transform)
+                    .ifPresent(terminalUi::update);
         } catch (IOException | InterruptedException e) {
             // ignore
         }

--- a/src/main/java/ninja/ranner/conductor/domain/RemoteTimer.java
+++ b/src/main/java/ninja/ranner/conductor/domain/RemoteTimer.java
@@ -1,0 +1,18 @@
+package ninja.ranner.conductor.domain;
+
+import java.time.Duration;
+import java.util.List;
+
+public record RemoteTimer(
+        String name,
+        Duration remaining,
+        State state,
+        List<String> participants
+) {
+    public enum State {
+        Waiting,
+        Running,
+        Paused,
+        Finished
+    }
+}

--- a/src/test/java/ninja/ranner/conductor/adapter/in/clock/SchedulerTest.java
+++ b/src/test/java/ninja/ranner/conductor/adapter/in/clock/SchedulerTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 
+@SuppressWarnings("resource")
 class SchedulerTest {
 
     @Test

--- a/src/test/java/ninja/ranner/conductor/adapter/out/http/ConductorApiClientTest.java
+++ b/src/test/java/ninja/ranner/conductor/adapter/out/http/ConductorApiClientTest.java
@@ -1,10 +1,12 @@
 package ninja.ranner.conductor.adapter.out.http;
 
-import org.junit.jupiter.api.Disabled;
+import ninja.ranner.conductor.domain.RemoteTimer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,18 +77,17 @@ public class ConductorApiClientTest {
     }
 
     @Test
-    @Disabled("test list")
     void nextTurnSendsPostRequest() throws Exception {
         HttpClient httpClient = HttpClient.createNull();
         var trackedRequests = httpClient.trackRequests();
         ConductorApiClient apiClient = new ConductorApiClient(httpClient, "https://conductor-api.example.com");
 
-        apiClient.pauseTimer("TIMER_NAME");
+        apiClient.nextTurn("TIMER_NAME");
 
         assertThat(trackedRequests.single())
                 .isEqualTo(new HttpClient.Request(
                         "POST",
-                        URI.create("https://conductor-api.example.com/timers/TIMER_NAME/pause"),
+                        URI.create("https://conductor-api.example.com/timers/TIMER_NAME/next_turn"),
                         ""
                 ));
     }
@@ -133,7 +134,7 @@ public class ConductorApiClientTest {
                 .respondingWith(new HttpClient.Response<>(200, """
                         {
                           "name": "my_timer",
-                          "status": "Waiting",
+                          "status": "Running",
                           "remainingSeconds": 32,
                           "participants": [
                             "Joe",
@@ -143,15 +144,13 @@ public class ConductorApiClientTest {
                         """)));
         ConductorApiClient apiClient = new ConductorApiClient(httpClient, "https://conductor-api.example.com");
 
-        Optional<ConductorApiClient.Timer> timer = apiClient.fetchTimer("TIMER_NAME");
+        Optional<RemoteTimer> timer = apiClient.fetchTimer("TIMER_NAME");
 
         assertThat(timer)
-                .isPresent();
-        assertThat(timer)
-                .contains(new ConductorApiClient.Timer(
+                .contains(new RemoteTimer(
                         "my_timer",
-                        "Waiting",
-                        32,
+                        Duration.of(32, ChronoUnit.SECONDS),
+                        RemoteTimer.State.Running,
                         List.of("Joe", "Abby")
                 ));
     }
@@ -162,7 +161,7 @@ public class ConductorApiClientTest {
                 .respondingWith(new HttpClient.Response<>(404, "")));
         ConductorApiClient apiClient = new ConductorApiClient(httpClient, "https://conductor-api.example.com");
 
-        Optional<ConductorApiClient.Timer> timer = apiClient.fetchTimer("TIMER_NAME");
+        Optional<RemoteTimer> timer = apiClient.fetchTimer("TIMER_NAME");
 
         assertThat(timer)
                 .isEmpty();

--- a/src/test/java/ninja/ranner/conductor/adapter/out/terminal/TerminalUiTest.java
+++ b/src/test/java/ninja/ranner/conductor/adapter/out/terminal/TerminalUiTest.java
@@ -1,5 +1,6 @@
 package ninja.ranner.conductor.adapter.out.terminal;
 
+import ninja.ranner.conductor.adapter.OutputTracker;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Nested;
@@ -74,6 +75,21 @@ public class TerminalUiTest {
             fixture.controls().simulateCommand("quit");
 
             uiThread.join(Duration.ofMillis(10));
+        }
+
+        @Test
+        void tracksUpdatedScreens() {
+            TerminalUi.Fixture fixture = TerminalUi.createNull();
+            OutputTracker<String> trackedScreens = fixture.terminalUi().trackScreens();
+
+            fixture.terminalUi().update(Lines.of("First Line", "", "Third Line"));
+
+            assertThat(trackedScreens.single())
+                    .isEqualTo("""
+                            First Line
+                                                       
+                            Third Line
+                            """);
         }
 
         private static ConditionFactory await() {

--- a/src/test/java/ninja/ranner/conductor/adapter/out/terminal/TimerTransformerTest.java
+++ b/src/test/java/ninja/ranner/conductor/adapter/out/terminal/TimerTransformerTest.java
@@ -1,7 +1,13 @@
 package ninja.ranner.conductor.adapter.out.terminal;
 
+import ninja.ranner.conductor.domain.RemoteTimer;
 import ninja.ranner.conductor.domain.Timer;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,5 +33,63 @@ class TimerTransformerTest {
 
         assertThat(result.all())
                 .containsExactly("Timer's up!");
+    }
+
+    @Test
+    void rendersRemoteTimer() {
+        RemoteTimer timer = new RemoteTimer(
+                "A_Timer",
+                Duration.of(5, ChronoUnit.MINUTES),
+                RemoteTimer.State.Paused,
+                List.of("Robin", "Jake", "Sarah")
+        );
+        TimerTransformer transformer = new TimerTransformer(null);
+
+        Lines lines = transformer.transform(timer);
+
+        assertThat(lines.all())
+                .containsExactly(
+                        "Time:        05:00 | Paused",
+                        "",
+                        "Navigator:   Robin",
+                        "Driver:      Jake",
+                        "Next Driver: Sarah"
+                );
+    }
+
+    @Test
+    void rendersRemoteTimerWithoutParticipants() {
+        RemoteTimer timer = new RemoteTimer(
+                "A_Timer",
+                Duration.of(123, ChronoUnit.SECONDS),
+                RemoteTimer.State.Paused,
+                Collections.emptyList()
+        );
+        TimerTransformer transformer = new TimerTransformer(null);
+
+        Lines lines = transformer.transform(timer);
+
+        assertThat(lines.all())
+                .containsExactly(
+                        "Time:        02:03 | Paused", ""
+                );
+    }
+
+    @Test
+    void rendersTurnIsUpMessageWhenDurationIsZero() {
+        RemoteTimer timer = new RemoteTimer(
+                "A_Timer",
+                Duration.ZERO,
+                RemoteTimer.State.Finished,
+                Collections.emptyList()
+        );
+        TimerTransformer transformer = new TimerTransformer(null);
+
+        Lines lines = transformer.transform(timer);
+
+        assertThat(lines.all())
+                .containsExactly(
+                        "Time:        Turn is up!", ""
+                );
     }
 }

--- a/src/test/java/ninja/ranner/conductor/application/RootTest.java
+++ b/src/test/java/ninja/ranner/conductor/application/RootTest.java
@@ -1,0 +1,65 @@
+package ninja.ranner.conductor.application;
+
+import ninja.ranner.conductor.adapter.OutputTracker;
+import ninja.ranner.conductor.adapter.in.clock.Scheduler;
+import ninja.ranner.conductor.adapter.out.http.ConductorApiClient;
+import ninja.ranner.conductor.adapter.out.terminal.TerminalUi;
+import ninja.ranner.conductor.adapter.out.terminal.TimerTransformer;
+import ninja.ranner.conductor.domain.RemoteTimer;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RootTest {
+
+    @Test
+    void onTick_fetchesRemoteTimer() throws InterruptedException {
+        Scheduler scheduler = Scheduler.createNull();
+        ConductorApiClient apiClient = ConductorApiClient.createNull();
+        OutputTracker<ConductorApiClient.Command> trackedCommands = apiClient.trackCommands();
+        TerminalUi tui = TerminalUi.createNull().terminalUi();
+        Root root = new Root(scheduler, tui, apiClient, "my_timer_name");
+        root.startInBackground();
+        Thread.sleep(1);
+
+        scheduler.simulateTick();
+
+        assertThat(trackedCommands.single())
+                .isEqualTo(new ConductorApiClient.Command.FetchTimer(
+                        "my_timer_name"));
+    }
+
+    @Test
+    void onTick_rendersRemoteTimer() throws InterruptedException {
+        RemoteTimer remoteTimer = new RemoteTimer(
+                "timer-name",
+                Duration.ofSeconds(55),
+                RemoteTimer.State.Paused,
+                List.of("Anna", "Bobby")
+        );
+        Scheduler scheduler = Scheduler.createNull();
+        ConductorApiClient apiClient = ConductorApiClient.createNull(c -> c
+                .returning(remoteTimer));
+        TerminalUi tui = TerminalUi.createNull().terminalUi();
+        OutputTracker<String> trackedScreens = tui.trackScreens();
+        Root root = new Root(scheduler, tui, apiClient, null);
+        root.startInBackground();
+        Thread.sleep(1);
+
+        scheduler.simulateTick();
+
+        assertThat(trackedScreens.all())
+                .containsExactly(
+                        // Clear screen
+                        "",
+
+                        // Rendered timer
+                        new TimerTransformer(null)
+                                .transform(remoteTimer)
+                                .toString());
+    }
+
+}


### PR DESCRIPTION
Renders timer fetched from remote [conductor-api](https://github.com/Suigi/conductor-api) (note: this repo is still private).

Currently uses the hard-coded timer `my-timer` and the hard-coded base URL `https://localhost:8080`.

Moved fetching and rendering orchestration from the `main()` method into a `Root` object in the `application` package.
Logic related to available commands and handling them still needs to be moved out of `main()` (but I'm not yet sure where it belongs).